### PR TITLE
Feature - Renames project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "component-library",
+  "name": "swyt-design-system",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
### Purpose / Goal
The name of the project was not unique enough, so updating it to `swyt-design-system`